### PR TITLE
fix: TypeScriptエラーを修正

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,3 +1,4 @@
+import { browser, type Browser } from 'wxt/browser'
 import { closeSameDomainTabs, closeSameSubdomainTabs, closeSameSubdirectoryTabs, groupSameDomainTabs } from '@/lib/tab-utils'
 import type { Message, ActionResponse, ActionType } from '@/types'
 
@@ -48,7 +49,7 @@ export default defineBackground(() => {
   )
 })
 
-async function executeAction(action: ActionType, tab: browser.Tabs.Tab): Promise<ActionResponse> {
+async function executeAction(action: ActionType, tab: Browser.tabs.Tab): Promise<ActionResponse> {
   try {
     switch (action) {
       case 'CLOSE_SAME_DOMAIN': {

--- a/lib/tab-utils.ts
+++ b/lib/tab-utils.ts
@@ -1,6 +1,7 @@
+import { browser, type Browser } from 'wxt/browser'
 import { matchesDomain, matchesSubdomain, matchesSubdirectory, parseURL } from './url-parser'
 
-type Tab = browser.tabs.Tab
+type Tab = Browser.tabs.Tab
 
 /**
  * Close all tabs with the same domain as the current tab
@@ -108,12 +109,13 @@ export async function groupSameDomainTabs(currentTab: Tab): Promise<number> {
   })
 
   const tabIds = matchingTabs.map((tab) => tab.id).filter((id): id is number => id !== undefined)
+  const [firstTabId, ...restTabIds] = tabIds
 
-  if (tabIds.length === 0) {
+  if (firstTabId === undefined) {
     throw new Error('No tabs to group')
   }
 
-  const groupId = await browser.tabs.group({ tabIds })
+  const groupId = await browser.tabs.group({ tabIds: [firstTabId, ...restTabIds] })
 
   await browser.tabGroups.update(groupId, {
     title: parsed.domain,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -20,7 +20,13 @@ const mockBrowser = {
   },
 }
 
-// Set browser mock in global scope
+// Mock wxt/browser module
+vi.mock('wxt/browser', () => ({
+  browser: mockBrowser,
+  Browser: {},
+}))
+
+// Set browser mock in global scope (for backward compatibility)
 Object.assign(globalThis, { browser: mockBrowser })
 
 // Reset all mocks before each test

--- a/tests/unit/tab-utils.test.ts
+++ b/tests/unit/tab-utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import type { Browser } from 'wxt/browser'
 import { mockBrowser } from '../setup'
 import {
   closeSameDomainTabs,
@@ -6,9 +7,12 @@ import {
   closeSameSubdirectoryTabs,
 } from '@/lib/tab-utils'
 
+type Tab = Browser.tabs.Tab
+
 describe('closeSameDomainTabs', () => {
   it('should close current tab when it matches the domain', async () => {
-    const currentTab = { id: 1, url: 'https://example.com/page1' }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: 'https://example.com/page1' } as Tab
     const tabs = [
       { id: 1, url: 'https://example.com/page1' },
       { id: 2, url: 'https://example.com/page2' },
@@ -26,7 +30,8 @@ describe('closeSameDomainTabs', () => {
 
 describe('closeSameSubdomainTabs', () => {
   it('should close current tab when it matches the subdomain', async () => {
-    const currentTab = { id: 1, url: 'https://docs.example.com/page1' }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: 'https://docs.example.com/page1' } as Tab
     const tabs = [
       { id: 1, url: 'https://docs.example.com/page1' },
       { id: 2, url: 'https://docs.example.com/page2' },
@@ -44,7 +49,8 @@ describe('closeSameSubdomainTabs', () => {
 
 describe('closeSameSubdirectoryTabs', () => {
   it('should close current tab when it matches the subdirectory', async () => {
-    const currentTab = { id: 1, url: 'https://example.com/docs/page1' }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: 'https://example.com/docs/page1' } as Tab
     const tabs = [
       { id: 1, url: 'https://example.com/docs/page1' },
       { id: 2, url: 'https://example.com/docs/page2' },


### PR DESCRIPTION
## Summary

- `wxt/browser`から明示的に`browser`と`Browser`型をインポートするように修正
- `browser.tabs.group()`の`tabIds`引数を非空タプル型`[number, ...number[]]`に適合するよう変換
- テストで`wxt/browser`モジュールをモック化してテストが正常に動作するよう修正

## Test plan

- [x] `pnpm typecheck` - エラーなし
- [x] `pnpm lint` - 0 errors
- [x] `pnpm test` - 22 tests passed
- [x] `pnpm build` - ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)