### PR TITLE
fix: エラーハンドリングパターンをResultに統一

### DIFF
--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -24,30 +24,31 @@ function setButtonsDisabled(disabled: boolean): void {
 async function sendAction(action: ActionType): Promise<void> {
   setButtonsDisabled(true);
 
-  try {
-    const response = await browser.runtime.sendMessage<{ action: ActionType }, ActionResponse>({
+  const response = await browser.runtime
+    .sendMessage<{ action: ActionType }, ActionResponse>({
       action,
-    });
+    })
+    .catch((error: unknown) => ({
+      success: false as const,
+      error: error instanceof Error ? error.message : "エラーが発生しました",
+    }));
 
-    if (response.success) {
-      switch (action) {
-        case "CLOSE_SAME_DOMAIN":
-        case "CLOSE_SAME_SUBDOMAIN":
-        case "CLOSE_SAME_SUBDIRECTORY":
-          showStatus(`${String(response.closedCount ?? 0)}個のタブを閉じました`);
-          break;
-        case "GROUP_BY_DOMAIN":
-          showStatus("タブをグループ化しました");
-          break;
-      }
-    } else {
-      showStatus(response.error ?? "エラーが発生しました", true);
+  if (response.success) {
+    switch (action) {
+      case "CLOSE_SAME_DOMAIN":
+      case "CLOSE_SAME_SUBDOMAIN":
+      case "CLOSE_SAME_SUBDIRECTORY":
+        showStatus(`${String(response.closedCount ?? 0)}個のタブを閉じました`);
+        break;
+      case "GROUP_BY_DOMAIN":
+        showStatus("タブをグループ化しました");
+        break;
     }
-  } catch (error) {
-    showStatus(error instanceof Error ? error.message : "エラーが発生しました", true);
-  } finally {
-    setButtonsDisabled(false);
+  } else {
+    showStatus(response.error ?? "エラーが発生しました", true);
   }
+
+  setButtonsDisabled(false);
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/lib/tab-utils.ts
+++ b/lib/tab-utils.ts
@@ -1,17 +1,18 @@
 import { browser, type Browser } from "wxt/browser";
 import { matchesDomain, matchesSubdomain, matchesSubdirectory, parseURL } from "./url-parser";
+import type { CloseTabsResult, GroupTabsResult } from "@/types";
 
 type Tab = Browser.tabs.Tab;
 
 /**
  * Close all tabs with the same domain as the current tab
- * Returns the number of closed tabs
+ * Returns the result with the number of closed tabs
  */
-export async function closeSameDomainTabs(currentTab: Tab): Promise<number> {
+export async function closeSameDomainTabs(currentTab: Tab): Promise<CloseTabsResult> {
   const { url: currentUrl, id: currentId } = currentTab;
 
   if (currentUrl === undefined || currentId === undefined) {
-    return 0;
+    return { success: false, error: "Current tab has no URL or ID" };
   }
 
   const allTabs = await browser.tabs.query({ currentWindow: true });
@@ -24,21 +25,28 @@ export async function closeSameDomainTabs(currentTab: Tab): Promise<number> {
 
   if (tabsToClose.length > 0) {
     const tabIds = tabsToClose.map((tab) => tab.id).filter((id): id is number => id !== undefined);
-    await browser.tabs.remove(tabIds);
+    const removeError = await browser.tabs
+      .remove(tabIds)
+      .catch((error: unknown) =>
+        error instanceof Error ? error.message : "Failed to remove tabs",
+      );
+    if (typeof removeError === "string") {
+      return { success: false, error: removeError };
+    }
   }
 
-  return tabsToClose.length;
+  return { success: true, closedCount: tabsToClose.length };
 }
 
 /**
  * Close all tabs with the same hostname (subdomain) as the current tab
- * Returns the number of closed tabs
+ * Returns the result with the number of closed tabs
  */
-export async function closeSameSubdomainTabs(currentTab: Tab): Promise<number> {
+export async function closeSameSubdomainTabs(currentTab: Tab): Promise<CloseTabsResult> {
   const { url: currentUrl, id: currentId } = currentTab;
 
   if (currentUrl === undefined || currentId === undefined) {
-    return 0;
+    return { success: false, error: "Current tab has no URL or ID" };
   }
 
   const allTabs = await browser.tabs.query({ currentWindow: true });
@@ -51,21 +59,28 @@ export async function closeSameSubdomainTabs(currentTab: Tab): Promise<number> {
 
   if (tabsToClose.length > 0) {
     const tabIds = tabsToClose.map((tab) => tab.id).filter((id): id is number => id !== undefined);
-    await browser.tabs.remove(tabIds);
+    const removeError = await browser.tabs
+      .remove(tabIds)
+      .catch((error: unknown) =>
+        error instanceof Error ? error.message : "Failed to remove tabs",
+      );
+    if (typeof removeError === "string") {
+      return { success: false, error: removeError };
+    }
   }
 
-  return tabsToClose.length;
+  return { success: true, closedCount: tabsToClose.length };
 }
 
 /**
  * Close all tabs with the same hostname and first path segment as the current tab
- * Returns the number of closed tabs
+ * Returns the result with the number of closed tabs
  */
-export async function closeSameSubdirectoryTabs(currentTab: Tab): Promise<number> {
+export async function closeSameSubdirectoryTabs(currentTab: Tab): Promise<CloseTabsResult> {
   const { url: currentUrl, id: currentId } = currentTab;
 
   if (currentUrl === undefined || currentId === undefined) {
-    return 0;
+    return { success: false, error: "Current tab has no URL or ID" };
   }
 
   const allTabs = await browser.tabs.query({ currentWindow: true });
@@ -78,26 +93,33 @@ export async function closeSameSubdirectoryTabs(currentTab: Tab): Promise<number
 
   if (tabsToClose.length > 0) {
     const tabIds = tabsToClose.map((tab) => tab.id).filter((id): id is number => id !== undefined);
-    await browser.tabs.remove(tabIds);
+    const removeError = await browser.tabs
+      .remove(tabIds)
+      .catch((error: unknown) =>
+        error instanceof Error ? error.message : "Failed to remove tabs",
+      );
+    if (typeof removeError === "string") {
+      return { success: false, error: removeError };
+    }
   }
 
-  return tabsToClose.length;
+  return { success: true, closedCount: tabsToClose.length };
 }
 
 /**
  * Group all tabs with the same domain as the current tab into a tab group
  * Returns the group ID
  */
-export async function groupSameDomainTabs(currentTab: Tab): Promise<number> {
+export async function groupSameDomainTabs(currentTab: Tab): Promise<GroupTabsResult> {
   const { url: currentUrl, id: currentId } = currentTab;
 
   if (currentUrl === undefined || currentId === undefined) {
-    throw new Error("Current tab has no URL or ID");
+    return { success: false, error: "Current tab has no URL or ID" };
   }
 
   const parsed = parseURL(currentUrl);
-  if (parsed === null) {
-    throw new Error("Could not parse current tab URL");
+  if (parsed === undefined) {
+    return { success: false, error: "Could not parse current tab URL" };
   }
 
   const allTabs = await browser.tabs.query({ currentWindow: true });
@@ -112,15 +134,30 @@ export async function groupSameDomainTabs(currentTab: Tab): Promise<number> {
   const [firstTabId, ...restTabIds] = tabIds;
 
   if (firstTabId === undefined) {
-    throw new Error("No tabs to group");
+    return { success: false, error: "No tabs to group" };
   }
 
-  const groupId = await browser.tabs.group({ tabIds: [firstTabId, ...restTabIds] });
+  const groupResult = await browser.tabs
+    .group({ tabIds: [firstTabId, ...restTabIds] })
+    .catch((error: unknown) =>
+      error instanceof Error ? error.message : "Failed to create tab group",
+    );
+  if (typeof groupResult === "string") {
+    return { success: false, error: groupResult };
+  }
+  const groupId = groupResult;
 
-  await browser.tabGroups.update(groupId, {
-    title: parsed.domain,
-    collapsed: false,
-  });
+  const updateError = await browser.tabGroups
+    .update(groupId, {
+      title: parsed.domain,
+      collapsed: false,
+    })
+    .catch((error: unknown) =>
+      error instanceof Error ? error.message : "Failed to update tab group",
+    );
+  if (typeof updateError === "string") {
+    return { success: false, error: updateError };
+  }
 
-  return groupId;
+  return { success: true, groupId };
 }

--- a/lib/url-parser.ts
+++ b/lib/url-parser.ts
@@ -3,31 +3,31 @@ import type { ParsedURL } from "@/types";
 /**
  * Parse a URL string into its components
  */
-export function parseURL(urlString: string): ParsedURL | null {
-  try {
-    const url = new URL(urlString);
-
-    // Skip non-http(s) URLs
-    if (!url.protocol.startsWith("http")) {
-      return null;
-    }
-
-    const { hostname, pathname, protocol } = url;
-    const domain = extractDomain(hostname);
-    const subdomain = extractSubdomain(hostname, domain);
-    const firstPathSegment = extractFirstPathSegment(pathname);
-
-    return {
-      protocol,
-      hostname,
-      domain,
-      subdomain,
-      pathname,
-      firstPathSegment,
-    };
-  } catch {
-    return null;
+export function parseURL(urlString: string): ParsedURL | undefined {
+  if (!URL.canParse(urlString)) {
+    return undefined;
   }
+
+  const url = new URL(urlString);
+
+  // Skip non-http(s) URLs
+  if (!url.protocol.startsWith("http")) {
+    return undefined;
+  }
+
+  const { hostname, pathname, protocol } = url;
+  const domain = extractDomain(hostname);
+  const subdomain = extractSubdomain(hostname, domain);
+  const firstPathSegment = extractFirstPathSegment(pathname);
+
+  return {
+    protocol,
+    hostname,
+    domain,
+    subdomain,
+    pathname,
+    firstPathSegment,
+  };
 }
 
 /**
@@ -111,7 +111,7 @@ export function matchesDomain(url1: string, url2: string): boolean {
   const parsed1 = parseURL(url1);
   const parsed2 = parseURL(url2);
 
-  if (parsed1 === null || parsed2 === null) {
+  if (parsed1 === undefined || parsed2 === undefined) {
     return false;
   }
 
@@ -125,7 +125,7 @@ export function matchesSubdomain(url1: string, url2: string): boolean {
   const parsed1 = parseURL(url1);
   const parsed2 = parseURL(url2);
 
-  if (parsed1 === null || parsed2 === null) {
+  if (parsed1 === undefined || parsed2 === undefined) {
     return false;
   }
 
@@ -139,7 +139,7 @@ export function matchesSubdirectory(url1: string, url2: string): boolean {
   const parsed1 = parseURL(url1);
   const parsed2 = parseURL(url2);
 
-  if (parsed1 === null || parsed2 === null) {
+  if (parsed1 === undefined || parsed2 === undefined) {
     return false;
   }
 

--- a/tests/unit/tab-utils.test.ts
+++ b/tests/unit/tab-utils.test.ts
@@ -5,12 +5,13 @@ import {
   closeSameDomainTabs,
   closeSameSubdomainTabs,
   closeSameSubdirectoryTabs,
+  groupSameDomainTabs,
 } from "@/lib/tab-utils";
 
 type Tab = Browser.tabs.Tab;
 
 describe("closeSameDomainTabs", () => {
-  it("should close current tab when it matches the domain", async () => {
+  it("should close all tabs with the same domain", async () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
     const currentTab = { id: 1, url: "https://example.com/page1" } as Tab;
     const tabs = [
@@ -21,15 +22,59 @@ describe("closeSameDomainTabs", () => {
     mockBrowser.tabs.query.mockResolvedValue(tabs);
     mockBrowser.tabs.remove.mockResolvedValue(undefined);
 
-    const count = await closeSameDomainTabs(currentTab);
+    const result = await closeSameDomainTabs(currentTab);
 
-    expect(count).toBe(2);
+    expect(result).toEqual({ success: true, closedCount: 2 });
     expect(mockBrowser.tabs.remove).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it("should return error when currentTab has no URL", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: undefined } as Tab;
+
+    const result = await closeSameDomainTabs(currentTab);
+
+    expect(result).toEqual({ success: false, error: "Current tab has no URL or ID" });
+    expect(mockBrowser.tabs.remove).not.toHaveBeenCalled();
+  });
+
+  it("should return error when currentTab has no ID", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: undefined, url: "https://example.com" } as Tab;
+
+    const result = await closeSameDomainTabs(currentTab);
+
+    expect(result).toEqual({ success: false, error: "Current tab has no URL or ID" });
+    expect(mockBrowser.tabs.remove).not.toHaveBeenCalled();
+  });
+
+  it("should return error when browser.tabs.remove fails", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: "https://example.com/page1" } as Tab;
+    const tabs = [{ id: 1, url: "https://example.com/page1" }];
+    mockBrowser.tabs.query.mockResolvedValue(tabs);
+    mockBrowser.tabs.remove.mockRejectedValue(new Error("Permission denied"));
+
+    const result = await closeSameDomainTabs(currentTab);
+
+    expect(result).toEqual({ success: false, error: "Permission denied" });
+  });
+
+  it("should return success with closedCount 0 when no matching tabs", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: "https://example.com/page1" } as Tab;
+    const tabs = [{ id: 2, url: "https://other.com" }];
+    mockBrowser.tabs.query.mockResolvedValue(tabs);
+
+    const result = await closeSameDomainTabs(currentTab);
+
+    expect(result).toEqual({ success: true, closedCount: 0 });
+    expect(mockBrowser.tabs.remove).not.toHaveBeenCalled();
   });
 });
 
 describe("closeSameSubdomainTabs", () => {
-  it("should close current tab when it matches the subdomain", async () => {
+  it("should close all tabs with the same subdomain", async () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
     const currentTab = { id: 1, url: "https://docs.example.com/page1" } as Tab;
     const tabs = [
@@ -40,15 +85,37 @@ describe("closeSameSubdomainTabs", () => {
     mockBrowser.tabs.query.mockResolvedValue(tabs);
     mockBrowser.tabs.remove.mockResolvedValue(undefined);
 
-    const count = await closeSameSubdomainTabs(currentTab);
+    const result = await closeSameSubdomainTabs(currentTab);
 
-    expect(count).toBe(2);
+    expect(result).toEqual({ success: true, closedCount: 2 });
     expect(mockBrowser.tabs.remove).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it("should return error when currentTab has no URL", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: undefined } as Tab;
+
+    const result = await closeSameSubdomainTabs(currentTab);
+
+    expect(result).toEqual({ success: false, error: "Current tab has no URL or ID" });
+    expect(mockBrowser.tabs.remove).not.toHaveBeenCalled();
+  });
+
+  it("should return error when browser.tabs.remove fails", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: "https://docs.example.com/page1" } as Tab;
+    const tabs = [{ id: 1, url: "https://docs.example.com/page1" }];
+    mockBrowser.tabs.query.mockResolvedValue(tabs);
+    mockBrowser.tabs.remove.mockRejectedValue(new Error("Permission denied"));
+
+    const result = await closeSameSubdomainTabs(currentTab);
+
+    expect(result).toEqual({ success: false, error: "Permission denied" });
   });
 });
 
 describe("closeSameSubdirectoryTabs", () => {
-  it("should close current tab when it matches the subdirectory", async () => {
+  it("should close all tabs with the same subdirectory", async () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
     const currentTab = { id: 1, url: "https://example.com/docs/page1" } as Tab;
     const tabs = [
@@ -59,9 +126,112 @@ describe("closeSameSubdirectoryTabs", () => {
     mockBrowser.tabs.query.mockResolvedValue(tabs);
     mockBrowser.tabs.remove.mockResolvedValue(undefined);
 
-    const count = await closeSameSubdirectoryTabs(currentTab);
+    const result = await closeSameSubdirectoryTabs(currentTab);
 
-    expect(count).toBe(2);
+    expect(result).toEqual({ success: true, closedCount: 2 });
     expect(mockBrowser.tabs.remove).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it("should return error when currentTab has no URL", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: undefined } as Tab;
+
+    const result = await closeSameSubdirectoryTabs(currentTab);
+
+    expect(result).toEqual({ success: false, error: "Current tab has no URL or ID" });
+    expect(mockBrowser.tabs.remove).not.toHaveBeenCalled();
+  });
+
+  it("should return error when browser.tabs.remove fails", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: "https://example.com/docs/page1" } as Tab;
+    const tabs = [{ id: 1, url: "https://example.com/docs/page1" }];
+    mockBrowser.tabs.query.mockResolvedValue(tabs);
+    mockBrowser.tabs.remove.mockRejectedValue(new Error("Permission denied"));
+
+    const result = await closeSameSubdirectoryTabs(currentTab);
+
+    expect(result).toEqual({ success: false, error: "Permission denied" });
+  });
+});
+
+describe("groupSameDomainTabs", () => {
+  it("should group all tabs with the same domain", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: "https://example.com/page1" } as Tab;
+    const tabs = [
+      { id: 1, url: "https://example.com/page1" },
+      { id: 2, url: "https://example.com/page2" },
+      { id: 3, url: "https://other.com" },
+    ];
+    mockBrowser.tabs.query.mockResolvedValue(tabs);
+    mockBrowser.tabs.group.mockResolvedValue(100);
+    mockBrowser.tabGroups.update.mockResolvedValue({});
+
+    const result = await groupSameDomainTabs(currentTab);
+
+    expect(result).toEqual({ success: true, groupId: 100 });
+    expect(mockBrowser.tabs.group).toHaveBeenCalledWith({ tabIds: [1, 2] });
+    expect(mockBrowser.tabGroups.update).toHaveBeenCalledWith(100, {
+      title: "example.com",
+      collapsed: false,
+    });
+  });
+
+  it("should return error when currentTab has no URL", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: undefined } as Tab;
+
+    const result = await groupSameDomainTabs(currentTab);
+
+    expect(result).toEqual({ success: false, error: "Current tab has no URL or ID" });
+    expect(mockBrowser.tabs.group).not.toHaveBeenCalled();
+  });
+
+  it("should return error when URL cannot be parsed", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: "not-a-valid-url" } as Tab;
+
+    const result = await groupSameDomainTabs(currentTab);
+
+    expect(result).toEqual({ success: false, error: "Could not parse current tab URL" });
+    expect(mockBrowser.tabs.group).not.toHaveBeenCalled();
+  });
+
+  it("should return error when no tabs to group", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: "https://example.com/page1" } as Tab;
+    const tabs = [{ id: undefined, url: "https://example.com/page1" }];
+    mockBrowser.tabs.query.mockResolvedValue(tabs);
+
+    const result = await groupSameDomainTabs(currentTab);
+
+    expect(result).toEqual({ success: false, error: "No tabs to group" });
+    expect(mockBrowser.tabs.group).not.toHaveBeenCalled();
+  });
+
+  it("should return error when browser.tabs.group fails", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: "https://example.com/page1" } as Tab;
+    const tabs = [{ id: 1, url: "https://example.com/page1" }];
+    mockBrowser.tabs.query.mockResolvedValue(tabs);
+    mockBrowser.tabs.group.mockRejectedValue(new Error("Cannot create group"));
+
+    const result = await groupSameDomainTabs(currentTab);
+
+    expect(result).toEqual({ success: false, error: "Cannot create group" });
+  });
+
+  it("should return error when browser.tabGroups.update fails", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion -- Test mock requires partial Tab object
+    const currentTab = { id: 1, url: "https://example.com/page1" } as Tab;
+    const tabs = [{ id: 1, url: "https://example.com/page1" }];
+    mockBrowser.tabs.query.mockResolvedValue(tabs);
+    mockBrowser.tabs.group.mockResolvedValue(100);
+    mockBrowser.tabGroups.update.mockRejectedValue(new Error("Cannot update group"));
+
+    const result = await groupSameDomainTabs(currentTab);
+
+    expect(result).toEqual({ success: false, error: "Cannot update group" });
   });
 });

--- a/tests/unit/url-parser.test.ts
+++ b/tests/unit/url-parser.test.ts
@@ -34,15 +34,15 @@ describe("parseURL", () => {
     });
   });
 
-  it("should return null for non-http URLs", () => {
-    expect(parseURL("chrome://extensions")).toBeNull();
-    expect(parseURL("file:///path/to/file")).toBeNull();
-    expect(parseURL("about:blank")).toBeNull();
+  it("should return undefined for non-http URLs", () => {
+    expect(parseURL("chrome://extensions")).toBeUndefined();
+    expect(parseURL("file:///path/to/file")).toBeUndefined();
+    expect(parseURL("about:blank")).toBeUndefined();
   });
 
-  it("should return null for invalid URLs", () => {
-    expect(parseURL("not a url")).toBeNull();
-    expect(parseURL("")).toBeNull();
+  it("should return undefined for invalid URLs", () => {
+    expect(parseURL("not a url")).toBeUndefined();
+    expect(parseURL("")).toBeUndefined();
   });
 });
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -23,3 +23,11 @@ export interface ParsedURL {
   pathname: string;
   firstPathSegment: string;
 }
+
+export type CloseTabsResult =
+  | { success: true; closedCount: number }
+  | { success: false; error: string };
+
+export type GroupTabsResult =
+  | { success: true; groupId: number }
+  | { success: false; error: string };

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     name: "Tab Management Extension",
     description: "Manage browser tabs - close by domain, subdomain, or group tabs together",
     permissions: ["tabs", "tabGroups", "contextMenus"],
+    minimum_chrome_version: "120",
   },
 });


### PR DESCRIPTION
## 概要

レビューで指摘されたエラーハンドリングの不一貫性を修正しました。

## 変更内容

- Close関数群とGroup関数の両方をResultパターン（判別可能なユニオン型）に統一
- background.ts の冗長な`.catch()`と`typeof`チェックを削除して可読性向上
- browser API（`browser.tabs.remove()`, `browser.tabs.group()`, `browser.tabGroups.update()`）を`.catch()`でラップ
- `parseURL()`をtry/catchから`URL.canParse()`に変更
- `null`から`undefined`に統一してCLAUDE.md規約に準拠
- 16のエラーケーステストを追加
- `minimum_chrome_version: '120'`を設定（`URL.canParse()`対応）

## テスト結果

✅ 型チェック: パス
✅ テスト: 36件すべてパス
✅ lint: エラーなし
✅ ビルド: 成功